### PR TITLE
Custom endpoint_url and ShardId

### DIFF
--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -21,19 +21,20 @@ class ShardReader(SubprocessLoop):
     # this can be influeced per-reader instance via the sleep_time arg
     DEFAULT_SLEEP_TIME = 1.0
 
-    def __init__(self, shard_id, shard_iter, record_queue, error_queue, boto3_session=None, sleep_time=None):
+    def __init__(self, shard_id, shard_iter, record_queue, error_queue, boto3_session=None, sleep_time=None, endpoint_url=None):
         self.shard_id = shard_id
         self.shard_iter = shard_iter
         self.record_queue = record_queue
         self.error_queue = error_queue
         self.boto3_session = boto3_session or boto3.Session()
+        self.endpoint_url = endpoint_url
         self.sleep_time = sleep_time or self.DEFAULT_SLEEP_TIME
         self.start()
 
     def begin(self):
         """Begin the shard reader main loop"""
         log.info("Shard reader for %s starting", self.shard_id)
-        self.client = self.boto3_session.client('kinesis')
+        self.client = self.boto3_session.client('kinesis', endpoint_url=self.endpoint_url)
         self.retries = 0
 
     def loop(self):
@@ -80,13 +81,14 @@ class KinesisConsumer(object):
     """
     LOCK_DURATION = 30
 
-    def __init__(self, stream_name, boto3_session=None, state=None, reader_sleep_time=None):
+    def __init__(self, stream_name, boto3_session=None, state=None, reader_sleep_time=None, endpoint_url=None):
         self.stream_name = stream_name
         self.error_queue = multiprocessing.Queue()
         self.record_queue = multiprocessing.Queue()
 
         self.boto3_session = boto3_session or boto3.Session()
-        self.kinesis_client = self.boto3_session.client('kinesis')
+        self.endpoint_url = endpoint_url
+        self.kinesis_client = self.boto3_session.client('kinesis', endpoint_url=endpoint_url)
 
         self.state = state
 
@@ -154,6 +156,7 @@ class KinesisConsumer(object):
                     self.error_queue,
                     boto3_session=self.boto3_session,
                     sleep_time=self.reader_sleep_time,
+                    endpoint_url=self.endpoint_url
                 )
             else:
                 log.debug(
@@ -198,6 +201,7 @@ class KinesisConsumer(object):
                             if not self.run:
                                 break
 
+                            item['ShardId']=shard_id
                             log.debug(item)
                             yield item
 

--- a/src/kinesis/producer.py
+++ b/src/kinesis/producer.py
@@ -59,7 +59,7 @@ class AsyncProducer(SubprocessLoop):
     MAX_SIZE = (2 ** 20)
     MAX_COUNT = 500
 
-    def __init__(self, stream_name, buffer_time, queue, max_count=None, max_size=None, boto3_session=None):
+    def __init__(self, stream_name, buffer_time, queue, max_count=None, max_size=None, boto3_session=None, endpoint_url=None):
         self.stream_name = stream_name
         self.buffer_time = buffer_time
         self.queue = queue
@@ -71,7 +71,8 @@ class AsyncProducer(SubprocessLoop):
 
         if boto3_session is None:
             boto3_session = boto3.Session()
-        self.client = boto3_session.client('kinesis')
+        self.endpoint_url = endpoint_url
+        self.client = boto3_session.client('kinesis', endpoint_url=endpoint_url)
 
         self.start()
 
@@ -135,10 +136,10 @@ class AsyncProducer(SubprocessLoop):
 class KinesisProducer(object):
     """Produce to Kinesis streams via an AsyncProducer"""
 
-    def __init__(self, stream_name, buffer_time=0.5, max_count=None, max_size=None, boto3_session=None):
+    def __init__(self, stream_name, buffer_time=0.5, max_count=None, max_size=None, boto3_session=None, endpoint_url=None):
         self.queue = multiprocessing.Queue()
         self.async_producer = AsyncProducer(stream_name, buffer_time, self.queue, max_count=max_count,
-                                            max_size=max_size, boto3_session=boto3_session)
+                                            max_size=max_size, boto3_session=boto3_session, endpoint_url=endpoint_url)
 
     def put(self, data, explicit_hash_key=None, partition_key=None):
         self.queue.put((data, explicit_hash_key, partition_key))

--- a/src/kinesis/state.py
+++ b/src/kinesis/state.py
@@ -13,10 +13,10 @@ log = logging.getLogger(__name__)
 
 
 class DynamoDB(object):
-    def __init__(self, table_name, boto3_session=None):
+    def __init__(self, table_name, boto3_session=None, endpoint_url=None):
         self.boto3_session = boto3_session or boto3.Session()
 
-        self.dynamo_resource = self.boto3_session.resource('dynamodb')
+        self.dynamo_resource = self.boto3_session.resource('dynamodb', endpoint_url=endpoint_url)
         self.dynamo_table = self.dynamo_resource.Table(table_name)
 
         self.shards = {}


### PR DESCRIPTION
Following changes:
- Add a possible custom endpoint_url to consumer, producer and state
- Return 'ShardId' in item